### PR TITLE
Drop support for ansible-core 2.15. Move 2.16 to EOL CI.

### DIFF
--- a/plugins/modules/ansible_galaxy_install.py
+++ b/plugins/modules/ansible_galaxy_install.py
@@ -202,7 +202,6 @@ class AnsibleGalaxyInstall(ModuleHelper):
     _RE_INSTALL_OUTPUT = re.compile(
         r'^(?:(?P<collection>\w+\.\w+):(?P<cversion>[\d\.]+)|- (?P<role>\w+\.\w+) \((?P<rversion>[\d\.]+)\)) was installed successfully$'
     )
-    ansible_version = None
 
     output_params = ('type', 'name', 'dest', 'requirements_file', 'force', 'no_deps')
     module = dict(
@@ -262,9 +261,6 @@ class AnsibleGalaxyInstall(ModuleHelper):
 
     def __init_module__(self):
         self.runner, self.vars.version = self._get_ansible_galaxy_version()
-        self.ansible_version = tuple(int(x) for x in self.vars.version.split('.')[:3])
-        if self.ansible_version < (2, 11):
-            self.module.fail_json(msg="Support for Ansible 2.9 and ansible-base 2.10 has been removed.")
         self.vars.set("new_collections", {}, change=True)
         self.vars.set("new_roles", {}, change=True)
         if self.vars.type != "collection":

--- a/plugins/modules/maven_artifact.py
+++ b/plugins/modules/maven_artifact.py
@@ -245,7 +245,6 @@ import tempfile
 import traceback
 import re
 
-from ansible_collections.community.general.plugins.module_utils.version import LooseVersion
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from re import match
 
@@ -648,10 +647,7 @@ def main():
         mutually_exclusive=([('version', 'version_by_spec')])
     )
 
-    if LooseVersion(ansible_version) < LooseVersion("2.12") and module.params['unredirected_headers']:
-        module.fail_json(msg="Unredirected Headers parameter provided, but your ansible-core version does not support it. Minimum version is 2.12")
-
-    if LooseVersion(ansible_version) >= LooseVersion("2.12") and module.params['unredirected_headers'] is None:
+    if module.params['unredirected_headers'] is None:
         # if the user did not supply unredirected params, we use the default, ONLY on ansible core 2.12 and above
         module.params['unredirected_headers'] = ['Authorization', 'Cookie']
 

--- a/tests/integration/targets/filter_lists_mergeby/tasks/main.yml
+++ b/tests/integration/targets/filter_lists_mergeby/tasks/main.yml
@@ -6,6 +6,5 @@
 - name: Test list_merge default options
   import_tasks: lists_mergeby_default.yml
 
-- name: Test list_merge non-default options in Ansible 2.10 and higher
+- name: Test list_merge non-default options
   import_tasks: lists_mergeby_2-10.yml
-  when: ansible_version.full is version('2.10', '>=')

--- a/tests/integration/targets/kernel_blacklist/tasks/main.yml
+++ b/tests/integration/targets/kernel_blacklist/tasks/main.yml
@@ -65,7 +65,7 @@
 - name: test deprecation
   assert:
     that:
-      - "'deprecations' not in bl_test_1 or (ansible_version.major == 2 and ansible_version.minor == 12)"
+      - "'deprecations' not in bl_test_1"
 
 - name: add new item to list
   community.general.kernel_blacklist:

--- a/tests/integration/targets/test_a_module/runme.yml
+++ b/tests/integration/targets/test_a_module/runme.yml
@@ -39,4 +39,3 @@
           - "'onyx_pfc_interface' is not community.general.a_module"
           # Tombstoned module
           - "'community.general.docker_image_facts' is not community.general.a_module"
-      when: ansible_version.string is version('2.10.0', '>=')

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -168,10 +168,8 @@ function cleanup
             ansible-test coverage xml --color -v --requirements --group-by command --group-by version ${stub:+"$stub"}
             cp -a tests/output/reports/coverage=*.xml "$SHIPPABLE_RESULT_DIR/codecoverage/"
 
-            if [ "${ansible_version}" != "2.9" ]; then
-                # analyze and capture code coverage aggregated by integration test target
-                ansible-test coverage analyze targets generate -v "$SHIPPABLE_RESULT_DIR/testresults/coverage-analyze-targets.json"
-            fi
+            # analyze and capture code coverage aggregated by integration test target
+            ansible-test coverage analyze targets generate -v "$SHIPPABLE_RESULT_DIR/testresults/coverage-analyze-targets.json"
 
             # upload coverage report to codecov.io only when using complete on-demand coverage
             if [ "${COVERAGE}" == "--coverage" ] && [ "${CHANGED}" == "" ]; then


### PR DESCRIPTION
Hi Felix, I spotted a few other things that could go away with 2.15, feel free to cherry pick or just merge it with your branch. 

Please note that this PR targets your fork/branch.